### PR TITLE
Handle non-numeric PORT values gracefully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run the application through the main module so the settings validator can
+# sanitize dynamic environment values like ``PORT`` before passing them to
+# Uvicorn.
+CMD ["python", "main.py"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: sh -c 'uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'
+web: python main.py

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ A simple crypto signal and backtesting bot using Binance public API, CoinGecko a
 ## Development
 ```bash
 pip install -r requirements.txt
-uvicorn main:app --reload
+# Run through the main module so environment-driven settings like ``PORT``
+# are validated before launching Uvicorn
+python main.py
 ```
 
 ## Tests

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 """Application configuration using pydantic-settings."""
 from __future__ import annotations
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -20,6 +21,20 @@ class Settings(BaseSettings):
     atr_max: float = 10000
     data_dir: str = "./data"
     log_level: str = "INFO"
+
+    @field_validator("port", mode="before")
+    @staticmethod
+    def validate_port(value: int | str | None) -> int:
+        """Ensure the port is a valid integer.
+
+        Environments sometimes provide the port as a non-numeric placeholder
+        (e.g. ``"${PORT}"``), which causes ``uvicorn`` to error. Fallback to
+        the default ``8000`` when the value can't be converted to ``int``.
+        """
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 8000
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
## Summary
- validate and default the PORT setting when environment provides a non-numeric value
- launch app via `python main.py` so uvicorn uses validated port
- run container through `main.py` in Dockerfile and update docs accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*


------
https://chatgpt.com/codex/tasks/task_e_689f3b094a648324bcbcce87cdfd8c15