### PR TITLE
Ensure container always executes main module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,8 @@ COPY . .
 # Run the application through the main module so the settings validator can
 # sanitize dynamic environment values like ``PORT`` before passing them to
 # Uvicorn.
-CMD ["python", "main.py"]
+# Use an entrypoint so platforms that override the container command still
+# execute the main module. ``main.py`` sanitizes environment variables like
+# ``PORT`` before handing them off to Uvicorn, preventing errors such as
+# ``Invalid value for '--port': ${PORT} is not a valid integer``.
+ENTRYPOINT ["python", "main.py"]


### PR DESCRIPTION
## Summary
- run app via `main.py` entrypoint so platforms overriding the command still sanitize PORT before passing to Uvicorn

## Testing
- `pytest` *(fails: No module named 'pkg_resources')*

------
https://chatgpt.com/codex/tasks/task_e_68a1564211808324bd7c34cf25afb2af