### PR TITLE
fix: specify start command for Railway deployment

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,2 @@
+[deploy]
+startCommand = "python main.py"


### PR DESCRIPTION
## Summary
- add `railway.toml` so Railway uses `python main.py` at startup and avoids invalid `${PORT}` issues

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'pkg_resources')*
- `pip install setuptools` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_68a1588b49d4832483a6fb0ba6176de4