### PR TITLE
Add pkg_resources shim for pandas_ta under NumPy 2

### DIFF
--- a/pkg_resources.py
+++ b/pkg_resources.py
@@ -1,0 +1,28 @@
+from importlib import metadata
+import numpy as _np
+
+# Ensure compatibility with packages expecting `numpy.NaN`
+if not hasattr(_np, "NaN"):
+    _np.NaN = _np.nan
+
+
+class DistributionNotFound(Exception):
+    """Exception raised when a distribution cannot be found."""
+
+
+def get_distribution(dist_name: str):
+    """Minimal replacement for pkg_resources.get_distribution.
+
+    Returns an object with ``version`` and ``location`` attributes
+    for the requested distribution.
+    """
+    try:
+        dist = metadata.distribution(dist_name)
+    except metadata.PackageNotFoundError as exc:
+        raise DistributionNotFound(str(exc)) from exc
+
+    class DistInfo:
+        version = dist.version
+        location = str(dist.locate_file(""))
+
+    return DistInfo()


### PR DESCRIPTION
## Summary
- Provide lightweight `pkg_resources` replacement using `importlib.metadata`
- Restore `numpy.NaN` alias for compatibility with libraries expecting it

## Testing
- `python main.py` *(fails: httpx.ProxyError 403 Forbidden)*
- `PYTHONPATH=. pytest -q` *(fails: ProxyError; indicators mismatch; signal expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68a15c3b15c48324bb3c00914c04520c