### PR TITLE
Ensure project modules importable during tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for test modules
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure tests import modules by adding project root to `sys.path`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16608fe388324b2917f35f8c5419e