### PR TITLE
Pin APScheduler to stable 3.x to avoid event loop errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ httpx
 pandas
 numpy
 pandas_ta
-apscheduler
+apscheduler<4
 pydantic-settings
 pytest


### PR DESCRIPTION
## Summary
- Pin APScheduler below version 4 to maintain compatibility with the existing scheduler code

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1688cd2b88324ac76b5425532bcb4