### PR TITLE
Fix parquet dependency and improve trading dashboard

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,6 +22,12 @@ class Settings(BaseSettings):
     data_dir: str = "./data"
     log_level: str = "INFO"
 
+    @field_validator("watchlist")
+    @classmethod
+    def dedup_watchlist(cls, v: list[str]) -> list[str]:
+        """Ensure watchlist has unique symbols preserving order."""
+        return list(dict.fromkeys(v))
+
     @field_validator("port", mode="before")
     @staticmethod
     def validate_port(value: int | str | None) -> int:

--- a/core/signals/engine.py
+++ b/core/signals/engine.py
@@ -93,6 +93,7 @@ def generate_signal(df: pd.DataFrame, settings: Settings) -> dict:
             "ema_slow": row["ema_slow"],
             "rsi": row["rsi"],
             "atr": atr,
+            "volume": row.get("volume"),
         },
         "risk": risk,
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/frontend/pages/1_Overview.py
+++ b/frontend/pages/1_Overview.py
@@ -17,6 +17,7 @@ client = get_client()
 build_sidebar(client)
 
 st.title("Overview")
+st.write("Monitoring day-trading metrics such as volume and RSI for selected pairs.")
 try:
     from streamlit_autorefresh import st_autorefresh
     st_autorefresh(interval=st.session_state.get("refresh_sec", 60) * 1000, key="auto")
@@ -36,7 +37,7 @@ for sig in signals:
     if sig.get("symbol") not in selected_symbols or sig.get("timeframe") != timeframe:
         continue
     with st.container():
-        cols = st.columns([2, 2, 2])
+        cols = st.columns([2, 2, 2, 2])
         with cols[0]:
             st.subheader(sig.get("symbol", ""))
             signal_badge(sig.get("signal", "FLAT"))
@@ -48,6 +49,14 @@ for sig in signals:
             st.write(f"TP2: {risk.get('tp2')}")
             st.caption(f"Updated: {sig.get('generated_at')}")
         with cols[2]:
+            ind = sig.get("indicators", {})
+            vol = ind.get("volume")
+            rsi = ind.get("rsi")
+            if vol is not None:
+                st.write(f"Volume: {vol:,.0f}")
+            if rsi is not None:
+                st.write(f"RSI: {rsi:.2f}")
+        with cols[3]:
             sparkline(sig.get("history", []))
         with st.expander("Indicators"):
             st.json(sig.get("indicators", {}))

--- a/frontend/pages/4_Settings.py
+++ b/frontend/pages/4_Settings.py
@@ -1,6 +1,8 @@
 """Settings page to update backend configuration."""
 from __future__ import annotations
 
+import time
+
 import streamlit as st
 from dotenv import load_dotenv
 
@@ -28,7 +30,7 @@ with st.form("config"):
 
 if submitted:
     payload = {
-        "watchlist": [s.strip().upper() for s in watchlist.split(",") if s.strip()],
+        "watchlist": list(dict.fromkeys(s.strip().upper() for s in watchlist.split(",") if s.strip())),
         "timeframes": [s.strip() for s in timeframes.split(",") if s.strip()],
         "rsi_overbought": rsi_overbought,
         "rsi_oversold": rsi_oversold,
@@ -38,3 +40,14 @@ if submitted:
         st.success("Configuration updated")
     except Exception as exc:
         st.error(f"Failed to update: {exc}")
+
+if st.button("Reset Watchlist"):
+    progress = st.progress(0)
+    for i in range(100):
+        time.sleep(0.01)
+        progress.progress(i + 1)
+    try:
+        client.update_config({"watchlist": []})
+        st.success("Watchlist reset")
+    except Exception as exc:
+        st.error(f"Failed to reset: {exc}")

--- a/frontend/utils/theme.py
+++ b/frontend/utils/theme.py
@@ -23,7 +23,7 @@ def inject_theme() -> None:
 def build_sidebar(client) -> None:
     """Render common sidebar controls and navigation."""
     config = client.get_config()
-    watchlist = config.get("watchlist", [])
+    watchlist = list(dict.fromkeys(config.get("watchlist", [])))
     timeframes = config.get("timeframes", [])
     st.session_state["theme"] = st.sidebar.selectbox(
         "Theme", ["Dark", "Light"],
@@ -42,6 +42,8 @@ def build_sidebar(client) -> None:
     st.sidebar.page_link("pages/2_Daily_Stats.py", label="Daily Stats")
     st.sidebar.page_link("pages/3_Backtest.py", label="Backtest")
     st.sidebar.page_link("pages/4_Settings.py", label="Settings")
+
+    st.sidebar.markdown(f"[API Docs]({client.base_url}/docs)")
 
     try:
         healthy = client.health().get("status") == "ok"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn
 httpx
 pandas
 numpy
+pyarrow
 pandas_ta
 apscheduler<4
 pydantic-settings

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,10 +8,17 @@
 </head>
 <body class="bg-gray-900 text-gray-100">
   <header class="bg-gray-800 shadow">
-    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8 flex justify-between items-center">
       <h1 class="text-3xl font-bold">Crypto Signal Dashboard</h1>
+      <nav class="space-x-4">
+        <a href="/" class="hover:underline">Home</a>
+        <a href="/docs" class="hover:underline">API Docs</a>
+      </nav>
     </div>
   </header>
+  <section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
+    <p class="text-gray-300">Monitor day-trading metrics such as volume and RSI for each asset.</p>
+  </section>
   <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
     <div id="signals" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"></div>
   </main>


### PR DESCRIPTION
## Summary
- add `pyarrow` dependency to enable parquet exports
- show volume and RSI metrics with navigation updates in web dashboard
- deduplicate watchlists with reset progress feedback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a19e5ac1dc83248567db6bef5e827a