### PR TITLE
Add symbols endpoint and CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple crypto signal and backtesting bot using Binance public API, CoinGecko a
 ## Endpoints
 The FastAPI backend exposes several JSON endpoints:
 - `GET /health` – service check
+- `GET /symbols` – list supported symbols
 - `GET /signals` – signal for symbol/timeframe
 - `GET /signals/batch` – all signals
 - `GET /stats/daily` – daily market statistics

--- a/api/routes.py
+++ b/api/routes.py
@@ -30,6 +30,12 @@ async def health() -> dict:
     return {"status": "ok"}
 
 
+@router.get("/symbols")
+async def get_symbols(settings: Settings = Depends(get_settings)) -> list[str]:
+    """Return supported trading symbols."""
+    return settings.watchlist
+
+
 @router.get("/config")
 async def get_config(settings: Settings = Depends(get_settings)) -> dict:
     return settings.model_dump()

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     port: int = 8000
     watchlist: list[str] = ["BTCUSDT", "ETHUSDT", "BNBUSDT", "SOLUSDT"]
     timeframes: list[str] = ["1m", "15m"]
+    allowed_origins: list[str] = ["*"]
     sched_interval_sec: int = 60
     ema_fast: int = 9
     ema_slow: int = 21
@@ -26,6 +27,12 @@ class Settings(BaseSettings):
     @classmethod
     def dedup_watchlist(cls, v: list[str]) -> list[str]:
         """Ensure watchlist has unique symbols preserving order."""
+        return list(dict.fromkeys(v))
+
+    @field_validator("allowed_origins")
+    @classmethod
+    def dedup_origins(cls, v: list[str]) -> list[str]:
+        """Ensure CORS origin list is unique while preserving order."""
         return list(dict.fromkeys(v))
 
     @field_validator("port", mode="before")

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import logging
 
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
+from fastapi.middleware.cors import CORSMiddleware
 from pathlib import Path
 
 from api.routes import router
@@ -16,6 +17,12 @@ from services.store import DataStore
 logging.basicConfig(level=getattr(logging, settings.log_level))
 
 app = FastAPI(title=settings.app_name)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_origins,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(router)
 
 store = DataStore()

--- a/tests/test_symbols_endpoint.py
+++ b/tests/test_symbols_endpoint.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from main import app
+from config import settings
+
+
+def test_symbols_endpoint_returns_watchlist_and_cors() -> None:
+    client = TestClient(app)
+    response = client.get("/symbols", headers={"Origin": "http://example.com"})
+    assert response.status_code == 200
+    assert response.json() == settings.watchlist
+    assert response.headers.get("access-control-allow-origin") == "*"


### PR DESCRIPTION
## Summary
- expose `/symbols` endpoint for configured watchlist
- enable configurable CORS support via `allowed_origins`
- document and test new endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a903e2cc8324845d3d5493df1d0a