### PR TITLE
Refactor startup lifecycle and HTTP client

### DIFF
--- a/core/datasources/coingecko.py
+++ b/core/datasources/coingecko.py
@@ -6,23 +6,25 @@ from typing import Any
 
 import httpx
 
+from services.http_client import get_client
+
 BASE_URL = "https://api.coingecko.com/api/v3"
 
 
 async def _request(path: str, params: dict[str, Any] | None = None, retries: int = 3) -> Any:
     url = f"{BASE_URL}{path}"
     backoff = 1
-    async with httpx.AsyncClient(timeout=10) as client:
-        for attempt in range(retries):
-            try:
-                resp = await client.get(url, params=params)
-                resp.raise_for_status()
-                return resp.json()
-            except httpx.HTTPError:
-                if attempt == retries - 1:
-                    raise
-                await asyncio.sleep(backoff)
-                backoff *= 2
+    client = get_client()
+    for attempt in range(retries):
+        try:
+            resp = await client.get(url, params=params)
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPError:
+            if attempt == retries - 1:
+                raise
+            await asyncio.sleep(backoff)
+            backoff *= 2
 
 
 async def simple_price(ids: list[str], vs_currencies: list[str]) -> dict[str, Any]:

--- a/core/datasources/fng.py
+++ b/core/datasources/fng.py
@@ -6,20 +6,22 @@ from typing import Any
 
 import httpx
 
+from services.http_client import get_client
+
 BASE_URL = "https://api.alternative.me/fng/"
 
 
 async def get_index(retries: int = 3) -> dict[str, Any]:
     backoff = 1
-    async with httpx.AsyncClient(timeout=10) as client:
-        for attempt in range(retries):
-            try:
-                resp = await client.get(BASE_URL)
-                resp.raise_for_status()
-                data = resp.json()
-                return data["data"][0]
-            except httpx.HTTPError:
-                if attempt == retries - 1:
-                    raise
-                await asyncio.sleep(backoff)
-                backoff *= 2
+    client = get_client()
+    for attempt in range(retries):
+        try:
+            resp = await client.get(BASE_URL)
+            resp.raise_for_status()
+            data = resp.json()
+            return data["data"][0]
+        except httpx.HTTPError:
+            if attempt == retries - 1:
+                raise
+            await asyncio.sleep(backoff)
+            backoff *= 2

--- a/services/http_client.py
+++ b/services/http_client.py
@@ -1,0 +1,24 @@
+"""Shared HTTP client for outgoing requests."""
+from __future__ import annotations
+
+import httpx
+
+_client: httpx.AsyncClient | None = None
+
+
+def get_client() -> httpx.AsyncClient:
+    """Return a singleton AsyncClient with sensible defaults."""
+    global _client
+    if _client is None:
+        timeout = httpx.Timeout(10.0, connect=5.0)
+        limits = httpx.Limits(max_connections=20, max_keepalive_connections=5)
+        _client = httpx.AsyncClient(timeout=timeout, limits=limits)
+    return _client
+
+
+async def close_client() -> None:
+    """Close the shared client if it was created."""
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None

--- a/services/scheduler.py
+++ b/services/scheduler.py
@@ -38,8 +38,16 @@ async def update_once(settings: Settings, store: DataStore) -> None:
                 df.to_csv(Path(settings.data_dir) / f"{symbol}_{tf}.csv", index=False)
 
 
-def start_scheduler(settings: Settings, store: DataStore) -> AsyncIOScheduler:
+def create_scheduler(settings: Settings, store: DataStore) -> AsyncIOScheduler:
+    """Configure the AsyncIO scheduler for periodic updates."""
     scheduler = AsyncIOScheduler()
-    scheduler.add_job(update_once, "interval", seconds=settings.sched_interval_sec, args=[settings, store])
-    scheduler.start()
+    scheduler.add_job(
+        update_once,
+        "interval",
+        seconds=settings.sched_interval_sec,
+        args=[settings, store],
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=settings.sched_interval_sec,
+    )
     return scheduler

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,22 @@
 <!DOCTYPE html>
 <html lang="en" class="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Crypto Signal Dashboard</title>
-  <script>
-    tailwind.config = { darkMode: 'class' }
-  </script>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crypto Signal Dashboard</title>
+    <link
+      rel="icon"
+      type="image/png"
+      href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PwFlqQAAAABJRU5ErkJggg=="
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PwFlqQAAAABJRU5ErkJggg=="
+    />
+    <script>
+      tailwind.config = { darkMode: 'class' }
+    </script>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">


### PR DESCRIPTION
## Summary
- replace deprecated event hooks with FastAPI lifespan
- centralize HTTP requests through a shared `httpx.AsyncClient`
- configure APScheduler to avoid overlapping runs
- embed dashboard icons directly to avoid binary assets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1e1cfb7748324af31a4f3fcf86289